### PR TITLE
ufo central: dont load config

### DIFF
--- a/lib/ufo/cli/central/base.rb
+++ b/lib/ufo/cli/central/base.rb
@@ -1,12 +1,23 @@
 class Ufo::CLI::Central
   class Base
-    include Ufo::Utils::Execute
-    include Ufo::Utils::Logging
     include Ufo::Utils::Pretty
     include Ufo::Utils::Sure
 
     def initialize(options={})
       @options = options
+    end
+
+    # Do not use logger.info for ufo central commands as .ufo may not be yet setup
+    # We do not want any config calls to trigger a loading of the .ufo/config.rb etc
+    # Otherwise helper methods like ecr_repo may be called and not work yet
+    def log(msg)
+      puts msg
+    end
+
+    # Central has own version of execute because it doesnt have access to logger
+    def execute(command)
+      log "=> #{command}"
+      system command
     end
   end
 end

--- a/lib/ufo/cli/central/clean.rb
+++ b/lib/ufo/cli/central/clean.rb
@@ -4,7 +4,7 @@ class Ufo::CLI::Central
       path = "#{ENV['HOME']}/.ufo/central"
       sure?("Will remove folder with repo caches: #{pretty_home(path)}")
       FileUtils.rm_rf(path)
-      logger.info "Removed: #{pretty_home(path)}"
+      log "Removed: #{pretty_home(path)}"
     end
   end
 end

--- a/lib/ufo/cli/central/update.rb
+++ b/lib/ufo/cli/central/update.rb
@@ -4,7 +4,7 @@ class Ufo::CLI::Central
       validate!
       action = File.exist?(".ufo") ? "update" : "create"
       sure?("Will #{action} the .ufo symlink") # IE: Will create the .ufo symlink
-      logger.info "Updating .ufo with #{central_repo}"
+      log "Updating .ufo with #{central_repo}"
       FileUtils.mkdir_p(tmp_area)
       pull
       symlink
@@ -12,7 +12,6 @@ class Ufo::CLI::Central
     end
 
     def pull
-      logger.debug "Within #{tmp_area}"
       Dir.chdir(tmp_area) do
         if File.exist?(repo)
           execute "cd #{repo} && git pull"
@@ -36,8 +35,8 @@ class Ufo::CLI::Central
 
       report_broken_symlink
 
-      logger.info "The .ufo symlink has been updated"
-      logger.info "Symlink: .ufo -> #{pretty_home(src)}"
+      log "The .ufo symlink has been updated"
+      log "Symlink: .ufo -> #{pretty_home(src)}"
     end
 
     def report_broken_symlink
@@ -62,8 +61,8 @@ class Ufo::CLI::Central
 
     def validate!
       return if central_repo
-      logger.info "ERROR: Please set the env var: UFO_CENTRAL_REPO".color(:red)
-      logger.info "The ufo central update command requires it."
+      log "ERROR: Please set the env var: UFO_CENTRAL_REPO".color(:red)
+      log "The ufo central update command requires it."
       exit 1
     end
 
@@ -104,8 +103,8 @@ class Ufo::CLI::Central
         end
       end
       return if ok
-      logger.info "No .ufo found in your .gitignore file".color(:yellow)
-      logger.info <<~EOL
+      log "No .ufo found in your .gitignore file".color(:yellow)
+      log <<~EOL
         It's recommended to add .ufo to the .gitignore
         When using ufo in a central fashion
       EOL

--- a/lib/ufo/command.rb
+++ b/lib/ufo/command.rb
@@ -38,8 +38,15 @@ module Ufo
         # loads Ufo.config and Ufo::Config#load_project_config
         # This requires Ufo.role.
         # So we set Ufo.role before triggering Ufo.config loading
-        configure_dsl_evaluator
         check_project!(args)
+        # Special case for `ufo central` commands.
+        # Dont want to call configure_dsl_evaluator
+        # and trigger loading of config => .ufo/config.rb
+        # Also, using ARGV instead of args because args is called by thor in multiple passes
+        # For `ufo central update`:
+        # * 1st pass: "central"
+        # * 2nd pass: "update"
+        configure_dsl_evaluator unless ARGV[0] == "central"
 
         # Allow calling for help via:
         #   ufo command help


### PR DESCRIPTION
* central commands are designed to be called without it
* when .ufo does exist by not loading configs
* it avoids trigger evaluating helpers which are not needed