### PR TITLE
Acm cert and user messaging improvements with config

### DIFF
--- a/lib/ufo/cfn/stack/builder/resources/listener_ssl.rb
+++ b/lib/ufo/cfn/stack/builder/resources/listener_ssl.rb
@@ -27,11 +27,11 @@ class Ufo::Cfn::Stack::Builder::Resources
     # nil on purpose
     def certificates
       ssl = Ufo.config.elb.ssl
-      normalize(ssl.certificates)
+      normalize(ssl.certificates) if ssl.certificates
     end
 
     def normalize(*certs)
-      certs = certs.flatten
+      certs = certs.flatten.compact
       certs.map do |cert|
         if cert.is_a?(String)
           {CertificateArn: cert}

--- a/lib/ufo/cfn/stack/vars.rb
+++ b/lib/ufo/cfn/stack/vars.rb
@@ -59,7 +59,8 @@ class Ufo::Cfn::Stack
 
     # if the configuration is set to anything then enable it
     def create_listener_ssl?
-      Ufo.config.elb.ssl.enabled
+      elb = Ufo.config.elb
+      elb.ssl.enabled && elb.ssl.certificates
     end
 
     def create_elb?

--- a/lib/ufo/core.rb
+++ b/lib/ufo/core.rb
@@ -16,7 +16,6 @@ module Ufo
       if @@config_loaded
         config.app
       else
-        call_line = caller.find {|l| l.include?('.ufo') }
         puts "ERROR: Using Ufo.app or :APP expansion very early in the UFO boot process".color(:red)
         puts <<~EOL.color(:red)
           The Ufo.app or :APP expansions are not yet available at this point
@@ -25,11 +24,9 @@ module Ufo
           1. Use the UFO_APP env var to set it, which allows it to be used.
           2. Hard code your actual app name.
 
-          Called from:
-
-              #{call_line}
-
         EOL
+        call_line = caller.find {|l| l.include?('.ufo') }
+        DslEvaluator.print_code(call_line)
         exit 1
       end
     end

--- a/lib/ufo/task_definition/helpers/acm.rb
+++ b/lib/ufo/task_definition/helpers/acm.rb
@@ -1,12 +1,29 @@
 module Ufo::TaskDefinition::Helpers
   module Acm
+    include Ufo::Utils::CallLine
+    include Ufo::Utils::Pretty
+
     # returns cert arn
     def acm_cert(domain)
       certs = acm_certs
       cert = certs.find do |c|
         c.domain_name == domain
       end
-      cert.certificate_arn if cert
+      if cert
+        cert.certificate_arn
+      else
+        # Logger causes infinite loop when waf helper used in .ufo/
+        call_line = ufo_config_call_line
+        logger.warn "WARN: ACM cert not found: #{domain}".color(:yellow)
+        logger.info <<~EOL
+          Called from:
+
+              #{call_line}
+
+          Are you sure it's exists?
+        EOL
+        nil
+      end
     end
 
     # TODO: handle when there are lots of certs by paging

--- a/lib/ufo/task_definition/helpers/acm.rb
+++ b/lib/ufo/task_definition/helpers/acm.rb
@@ -13,15 +13,9 @@ module Ufo::TaskDefinition::Helpers
         cert.certificate_arn
       else
         # Logger causes infinite loop when waf helper used in .ufo/
-        call_line = ufo_config_call_line
         logger.warn "WARN: ACM cert not found: #{domain}".color(:yellow)
-        logger.info <<~EOL
-          Called from:
-
-              #{call_line}
-
-          Are you sure it's exists?
-        EOL
+        call_line = ufo_config_call_line
+        DslEvaluator.print_code(call_line)
         nil
       end
     end

--- a/lib/ufo/task_definition/helpers/ecr.rb
+++ b/lib/ufo/task_definition/helpers/ecr.rb
@@ -11,14 +11,9 @@ module Ufo::TaskDefinition::Helpers
       resp = ecr.describe_repositories(repository_names: [name])
       resp.repositories.first
     rescue Aws::ECR::Errors::RepositoryNotFoundException => e
-      call_line = ufo_config_call_line
       logger.warn "WARN: #{e.class} #{e.message}".color(:yellow)
-      logger.warn <<~EOL
-        Called from
-
-            #{call_line}
-
-      EOL
+      call_line = ufo_config_call_line
+      DslEvaluator.print_code(call_line)
       nil
     end
   end

--- a/lib/ufo/task_definition/helpers/waf.rb
+++ b/lib/ufo/task_definition/helpers/waf.rb
@@ -19,15 +19,9 @@ module Ufo::TaskDefinition::Helpers
         web_acl.arn
       else
         # Logger causes infinite loop when waf helper used in .ufo/
-        call_line = ufo_config_call_line
         logger.warn "WARN: Web ACL not found: #{name}".color(:yellow)
-        logger.info <<~EOL
-          Called from:
-
-              #{call_line}
-
-          Are you sure it's a regional WAF ACL?
-        EOL
+        call_line = ufo_config_call_line
+        DslEvaluator.print_code(call_line)
       end
     end
   end

--- a/lib/ufo/utils/call_line.rb
+++ b/lib/ufo/utils/call_line.rb
@@ -3,8 +3,7 @@ module Ufo::Utils
     include Pretty
 
     def ufo_config_call_line
-      call_line = caller.find { |l| l.include?('.ufo/') }
-      pretty_path(call_line)
+      caller.find { |l| l.include?('.ufo/') }
     end
   end
 end

--- a/lib/ufo/utils/squeezer.rb
+++ b/lib/ufo/utils/squeezer.rb
@@ -9,7 +9,9 @@ module Ufo::Utils
 
       case data
       when Array
-        data.map! { |v| squeeze(v) }
+        # .compact prevents infinite loop when data = [nil] on accident
+        # IE: config.elb.ssl.certificates = acm_cert("domain.not.found")
+        data.compact.map! { |v| squeeze(v) }
       when Hash
         data.each_with_object({}) do |(k,v), squeezed|
           # only remove nil and empty Array values within Hash structures

--- a/spec/ufo/utils/squeezer_spec.rb
+++ b/spec/ufo/utils/squeezer_spec.rb
@@ -1,0 +1,21 @@
+describe Ufo::Utils::Squeezer do
+  subject { Ufo::Utils::Squeezer.new(data) }
+
+  context("Array with nil") do
+    let(:data) { [nil] }
+    # Prevents infinite loop
+    it "remove nil" do
+      squeezed = subject.squeeze
+      expect(squeezed).to eq []
+    end
+  end
+
+  context("Hash with nil value") do
+    let(:data) { {a: 1, b: nil } }
+    # Prevents infinite loop
+    it "remove nil" do
+      squeezed = subject.squeeze
+      expect(squeezed).to eq(a: 1)
+    end
+  end
+end

--- a/ufo.gemspec
+++ b/ufo.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cfn-status"
   spec.add_dependency "cli-format"
   spec.add_dependency "deep_merge"
-  spec.add_dependency "dsl_evaluator", ">= 0.2.5" # for DslEvaluator.print_code
+  spec.add_dependency "dsl_evaluator", ">= 0.3.0" # for DslEvaluator.print_code
   spec.add_dependency "memoist"
   spec.add_dependency "plissken"
   spec.add_dependency "rainbow"


### PR DESCRIPTION
acm_cert helper improvements: warn when not found and only create ssl listener if cert is found

messaging improvements: provide exact line of context of the config with the issue
    
* update dsl_evaluator dependency to at least 0.3.0
    
improve squeezer: prevent infinite loop for edge case when data is [nil]
    
* could happen before when config.elb.ssl.certificates = nil
* ListenerSsl#certificates -> normalize which then produces [nil]
* the squeezer would go into an infinite loop with this super edge case
* added additional safeguards by checking for ssl.certificates for nil
* and certs.flatten.compact and create_listener_ssl? check
* also add spec