### PR TITLE
infer elb dns name from target group when possible

### DIFF
--- a/lib/ufo/cfn/stack/vars.rb
+++ b/lib/ufo/cfn/stack/vars.rb
@@ -69,8 +69,7 @@ class Ufo::Cfn::Stack
       if create_elb?
         true
       else
-        !!(Ufo.config.elb.existing.target_group &&
-           Ufo.config.elb.existing.dns_name)
+        Ufo.config.elb.existing.target_group
       end
     end
 


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Infer elb dns name from target group when possible. This makes `config.existing.dns_name` optional. However, it's required when the target group is associated with multiple load balancers.

## Context

https://github.com/boltops-tools/ufo/pull/164

## How to Test

Follow docs: https://ufoships.com/docs/features/load-balancer/existing/

## Version Changes

Patch