### PR TITLE
fix edge case include_dir for ruby 2.7

### DIFF
--- a/lib/ufo/task_definition/helpers/aws_helper.rb
+++ b/lib/ufo/task_definition/helpers/aws_helper.rb
@@ -1,4 +1,4 @@
-module Ufo::TaskDefinition::Helpers::Vars
+module Ufo::TaskDefinition::Helpers
   # Named AwsHelper to avoid possible conflict with Aws elsewhere
   module AwsHelper
     extend Memoist

--- a/lib/ufo/task_definition/helpers/vars/builder.rb
+++ b/lib/ufo/task_definition/helpers/vars/builder.rb
@@ -3,9 +3,9 @@ require "aws_data"
 module Ufo::TaskDefinition::Helpers::Vars
   class Builder
     extend Memoist
-    include AwsHelper
     include Ufo::Concerns::Names
     include Ufo::Config::CallableOption::Concern
+    include Ufo::TaskDefinition::Helpers::AwsHelper
     include Ufo::Utils::CallLine
     include Ufo::Utils::Logging
     include Ufo::Utils::Pretty


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Edge case that only happens on ruby 2.7. Ok on ruby 3.0

## Context

N/A

## How to Test

Run acceptance test.

## Version Changes

Patch