### PR TITLE
infer ecs managed sg based on awsvpc network mode

### DIFF
--- a/lib/ufo/cfn/stack/builder/resources/security_group/ecs.rb
+++ b/lib/ufo/cfn/stack/builder/resources/security_group/ecs.rb
@@ -1,7 +1,8 @@
 module Ufo::Cfn::Stack::Builder::Resources::SecurityGroup
   class Ecs < Base
     def build
-      return unless managed_security_groups?
+      return unless manage_ecs_security_group?
+      return unless vars[:container][:network_mode].to_s == 'awsvpc'
 
       {
         Type: "AWS::EC2::SecurityGroup",

--- a/lib/ufo/cfn/stack/builder/resources/security_group/ecs_rule.rb
+++ b/lib/ufo/cfn/stack/builder/resources/security_group/ecs_rule.rb
@@ -1,8 +1,7 @@
 module Ufo::Cfn::Stack::Builder::Resources::SecurityGroup
   class EcsRule < Base
     def build
-      return unless managed_security_groups?
-      return unless vars[:elb_type] == "application"
+      return unless manage_ecs_security_group?
 
       {
         Type: "AWS::EC2::SecurityGroupIngress",

--- a/lib/ufo/cfn/stack/builder/resources/security_group/elb.rb
+++ b/lib/ufo/cfn/stack/builder/resources/security_group/elb.rb
@@ -1,7 +1,7 @@
 module Ufo::Cfn::Stack::Builder::Resources::SecurityGroup
   class Elb < Base
     def build
-      return unless managed_security_groups?
+      # Always create elb security group it seems like its required
       return unless vars[:elb_type] == "application"
 
       {

--- a/lib/ufo/config.rb
+++ b/lib/ufo/config.rb
@@ -138,7 +138,6 @@ module Ufo
       config.vpc.security_groups = ActiveSupport::OrderedOptions.new
       config.vpc.security_groups.ecs = nil
       config.vpc.security_groups.elb = nil
-      config.vpc.security_groups.managed = true
       config.vpc.subnets = ActiveSupport::OrderedOptions.new
       config.vpc.subnets.ecs = nil
       config.vpc.subnets.elb = nil


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This removes extra security group noise from the unused ECS security group.

* remove vpc.security_groups.managed and automatically
* fix edge case when ecs service still sees stale elb

## How to Test

Run acceptance test.

## Version Changes

Patch