### PR TITLE
default unhealthy_threshold_count = 3

### DIFF
--- a/lib/ufo/config.rb
+++ b/lib/ufo/config.rb
@@ -70,7 +70,7 @@ module Ufo
       config.elb.health_check_interval_seconds = 10 # keep at 10 in case of network ELB, which is min 10
       config.elb.health_check_path = nil # When nil its AWS default /
       config.elb.healthy_threshold_count = 3 # The AWS usual default is 5
-      config.elb.unhealthy_threshold_count = 2
+      config.elb.unhealthy_threshold_count = 3
 
       config.elb.port = 80 # default listener port
       config.elb.redirect = ActiveSupport::OrderedOptions.new


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Adjust the default unhealthy_threshold_count = 3. This combined with the default health_check_interval_seconds of 10 means the default ELB unhealthy timeout is 30s. This should fix the intermittent reported ECS task stopped error during deployment.

```
Task Stopped Reason: Task failed ELB health checks in (target-group...)
```


## Context

Would sometimes see intermittent ECS task stop error during deployment.

## How to Test

Hard to reproduce. But just do a sanity check.

## Version Changes

Patch