### PR TITLE
support multiple ssl certs

### DIFF
--- a/lib/ufo/cfn/stack/builder/resources.rb
+++ b/lib/ufo/cfn/stack/builder/resources.rb
@@ -10,6 +10,7 @@ class Ufo::Cfn::Stack::Builder
         ElbSecurityGroup: SecurityGroup::Elb.build(@options),
         ExecutionRole: IamRoles::ExecutionRole.build(@options),
         Listener: Listener.build(@options),
+        ListenerCertificate: ListenerCertificate.build(@options),
         ListenerSsl: ListenerSsl.build(@options),
         TargetGroup: TargetGroup.build(@options),
         TaskDefinition: TaskDefinition.build(@options),

--- a/lib/ufo/cfn/stack/builder/resources/listener_certificate.rb
+++ b/lib/ufo/cfn/stack/builder/resources/listener_certificate.rb
@@ -1,0 +1,30 @@
+class Ufo::Cfn::Stack::Builder::Resources
+  class ListenerCertificate < ListenerSsl
+    def build
+      return unless certificates.size >= 1 # already removed firt cert
+      {
+        Type: "AWS::ElasticLoadBalancingV2::ListenerCertificate",
+        Condition: "CreateElbIsTrue",
+        Properties: properties,
+      }
+    end
+
+    def properties
+      {
+        Certificates: certificates,
+        ListenerArn: {Ref: "ListenerSsl"}
+      }
+    end
+
+    def certificates
+      ssl = Ufo.config.elb.ssl
+      certs = normalize(ssl.certificates) if ssl.certificates
+      # CloudFormation has weird interface
+      # Only one cert allowed at the AWS::ElasticLoadBalancingV2::Listener
+      # https://stackoverflow.com/questions/54447250/how-to-set-multiple-certificates-for-awselasticloadbalancingv2listener
+      # Also note the docs say "You can specify one certificate per resource."
+      # But tested and multiple certs here work
+      certs[1..-1] # dont include the first one
+    end
+  end
+end

--- a/lib/ufo/cfn/stack/builder/resources/listener_ssl.rb
+++ b/lib/ufo/cfn/stack/builder/resources/listener_ssl.rb
@@ -7,7 +7,10 @@ class Ufo::Cfn::Stack::Builder::Resources
 
     def properties
       props = super
-      props[:Certificates] = certificates
+      # CloudFormation has weird interface
+      # Only one cert allowed at the AWS::ElasticLoadBalancingV2::Listener
+      # https://stackoverflow.com/questions/54447250/how-to-set-multiple-certificates-for-awselasticloadbalancingv2listener
+      props[:Certificates] = [certificates.first] # first one only
       props
     end
 


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Multiple ACM certs support.  CloudFormation has awkward interface where have to create an additional [AWS::ElasticLoadBalancingV2::ListenerCertificate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenercertificate.html) resource.

See: https://stackoverflow.com/questions/54447250/how-to-set-multiple-certificates-for-awselasticloadbalancingv2listener


## How to Test

Sanity check

## Version Changes

Patch