### PR TITLE
Secrets autofix and add missing trailing ::

### DIFF
--- a/lib/ufo/cli/help/new/env_file.md
+++ b/lib/ufo/cli/help/new/env_file.md
@@ -1,0 +1,11 @@
+## Examples
+
+Generate regular env file
+
+    $ ufo new env_file
+          create  .ufo/env_files/dev.env
+
+Generate secrets env file
+
+    $ ufo new env_file secrets
+          create  .ufo/env_files/dev.secrets

--- a/lib/ufo/cli/new/env_file.rb
+++ b/lib/ufo/cli/new/env_file.rb
@@ -12,7 +12,7 @@ class Ufo::CLI::New
   public
     def create_hook
       set_template_source("env_file")
-      template "file.#{type}", ".ufo/config/env_files/#{Ufo.env}.#{type}"
+      template "file.#{type}", ".ufo/env_files/#{Ufo.env}.#{type}"
     end
   end
 end

--- a/lib/ufo/task_definition/helpers/vars/builder.rb
+++ b/lib/ufo/task_definition/helpers/vars/builder.rb
@@ -41,7 +41,6 @@ module Ufo::TaskDefinition::Helpers::Vars
     end
 
     def show_layers(paths)
-      label = @ext.sub('.','').capitalize
       paths.each do |path|
         if ENV['UFO_LAYERS_ALL']
           logger.info "    #{path}"
@@ -85,10 +84,18 @@ module Ufo::TaskDefinition::Helpers::Vars
         value = item.delete(:value)
         arn = normalize_to_arn(item[:name], value)
         value = expansion(arn)
-        value = value.sub('parameter//','parameter/') # auto fix accidental leading slash for user
+        value = autofix(value)
         item[:valueFrom] = value
       end
       secrets
+    end
+
+    def autofix(value)
+      value = value.sub('parameter//','parameter/') # auto fix accidental leading slash for user
+      if value.include?(':secret:') && value.count(':') == 7 # missing trailing ::
+        value += "::"
+      end
+      value
     end
 
     def normalize_to_arn(name, value)


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

The ECS Secrets docs, [Injecting sensitive data as an environment variable](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html#secrets-envvar), state that you can specify the json key when referencing the secret like so:

    arn:aws:secretsmanager:region:aws_account_id:secret:secret-name:json-key:version-stage:version-id

The notation is a little awkward when to use the latest version stage and version and ends in `::`. Example:

    arn:aws:secretsmanager:us-west-2:111111111:secret:mysecret:mykey::

This means if you have a secret called `demo/dev/DB` with a JSON value like so

```json
{
    "pass": "mypass"
}
```

The secrets file would like look this:

.ufo/env_files/dev.secrets

    PASS=secretsmanager:demo/dev/DB:pass::

Since it is easy to forget the trailing `::`, UFO will automatically add the `::` if it sees it missing. So this also works

.ufo/env_files/dev.secrets

    PASS=secretsmanager:demo/dev/DB:pass


## How to Test

Run sanity acceptance test 

## Version Changes

Patch