### PR TITLE
use .ufo/tmp folder instead of /tmp/ufo

### DIFF
--- a/lib/ufo/task_definition/erb.rb
+++ b/lib/ufo/task_definition/erb.rb
@@ -41,7 +41,7 @@ class Ufo::TaskDefinition
     def evaluate_code
       path = @task_definition.path
       text = RenderMePretty.result(path, context: self)
-      rendered_path = "/tmp/ufo/task_definition#{File.extname(path)}"
+      rendered_path = "#{Ufo.root}/.ufo/tmp/task_definition#{File.extname(path)}"
       FileUtils.mkdir_p(File.dirname(rendered_path))
       IO.write(rendered_path, text)
 

--- a/lib/ufo/yaml.rb
+++ b/lib/ufo/yaml.rb
@@ -2,7 +2,7 @@ module Ufo
   class Yaml
     class << self
       def load(text)
-        path = "/tmp/ufo/temp.yml"
+        path = "#{Ufo.root}/.ufo/tmp/temp.yml"
         FileUtils.mkdir_p(File.dirname(path))
         IO.write(path, text)
         Validator.new(path).validate!


### PR DESCRIPTION
- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Write tmp files like task_definition in .ufo/tmp instead of /tmp/ufo in case using a shared deploy box with multiple users.

## How to Test

Run acceptance test suite

## Version Changes

Patch