### PR TITLE
auto continue_update_rollback and retry once

### DIFF
--- a/lib/ufo/task_definition/helpers/stack_output.rb
+++ b/lib/ufo/task_definition/helpers/stack_output.rb
@@ -2,6 +2,7 @@ module Ufo::TaskDefinition::Helpers
   module StackOutput
     include Ufo::AwsServices
     include Ufo::Concerns::Names
+    include Ufo::Utils::Logging
 
     def stack_output(name)
       stack_name, output_key = name.split(".")


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Super edge case where stack is in UPDATE_ROLLBACK_FAILED. Can reproduce by:

1. spinning ECS cluster down to 0 and deploying with ufo ship
2. after 3h will timeout and fail and goes into UPDATE_ROLLBACK_FAILED

Screenshot:

![Screen Shot 2022-07-11 at 9 56 12 AM](https://user-images.githubusercontent.com/4085/178319138-acd7d2d0-f3ab-4b31-a841-e0040e9c7911.png)

Will auto-retry once

## How to Test

Run ufo acceptance tests

## Version Changes

Patch