### PR TITLE
add ufo role and dev to image name tag

### DIFF
--- a/lib/ufo/docker/builder.rb
+++ b/lib/ufo/docker/builder.rb
@@ -141,7 +141,7 @@ module Ufo::Docker
     end
 
     def generate_name
-      ["#{image_name}:#{@image_namespace}-#{timestamp}", git_sha].compact.join('-') # compact in case git_sha is unavailable
+      ["#{image_name}:#{@image_namespace}", Ufo.role, Ufo.env, timestamp, git_sha].compact.join('-') # compact in case git_sha is unavailable
     end
 
     def docker_name_path


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix super edge case for colliding docker image name tag. Can happen when:

* Running codepipeline
* Dynamically building a different Dockerfile.erb based on UFO_ROLE
* The codebuild jobs running in parallel happen to build the docker image at the exact same time.

The 2 ECS Task definitions accidentally refer to the same image name tag. The last docker image pushed is used.

Adding ufo role and env to the name to avoid possibly collision. Not adding ufo app to the image tag since usually the repo name already has the app name and it would look redundant.

## Context

Ran into this dog-fooding the tool.

## How to Test

Sanity

## Version Changes

Patch